### PR TITLE
Adding coverage summary table

### DIFF
--- a/modules/plot_coverage.nf
+++ b/modules/plot_coverage.nf
@@ -54,3 +54,25 @@ process MULTI_SAMPLE_PLOT {
         """
 
 }
+
+process COVERAGE_SUMMARY {
+
+    /* */
+
+    publishDir params.alignment, mode: 'copy', overwrite: true
+
+	errorStrategy { task.attempt < 3 ? 'retry' : 'ignore' }
+	maxRetries 2
+
+    input:
+    path collected_passing_cov
+
+    output:
+    path "coverage_summary.tsv", emit: coverage_summary
+
+    script:
+    """
+    awk -F"\t" 'BEGIN {print "sample id\tproportion ≥ specified depth"} \$1!="sample id"{print \$1, \$4;}' *.tsv > coverage_summary.tsv
+    """
+
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
     "virus",
     "SARS-CoV-2",
     "H5N1",
-    "influenze",
+    "influenza",
     "haplotyping",
 ]
 classifiers = [

--- a/subworkflows/alignment.nf
+++ b/subworkflows/alignment.nf
@@ -5,7 +5,8 @@ include { ALIGN_WITH_PRESET       } from "../modules/minimap2"
 include { CONVERT_AND_SORT ; SORT_BAM ; INDEX } from "../modules/samtools"
 include { RASUSA_ALN_DOWNSAMPLING } from "../modules/rasusa"
 include { MOSDEPTH                } from "../modules/mosdepth"
-include { PLOT_COVERAGE ; MULTI_SAMPLE_PLOT } from "../modules/plot_coverage"
+include { PLOT_COVERAGE ; MULTI_SAMPLE_PLOT ; COVERAGE_SUMMARY } from "../modules/plot_coverage"
+
 
 
 workflow ALIGNMENT {
@@ -49,6 +50,10 @@ workflow ALIGNMENT {
 
     MULTI_SAMPLE_PLOT(
         MOSDEPTH.out.map { _sample_id, files -> files }.flatten().filter { mosdepth_file -> mosdepth_file.toString().endsWith(".per-base.bed") }.collect(),
+    )
+
+    COVERAGE_SUMMARY(
+        PLOT_COVERAGE.out.passing_cov.collect()
     )
 
     emit:


### PR DESCRIPTION
This should resolve #47, if it works. I have not rigorously tested this.

The logic is to collect all the mosdepth tsv files for each sample, then use a quick awk script to make a summary table. The script adds a header and then drops any headers it finds within the per-sample tsv files. I slotted it into the alignment workflow.