### PR TITLE
Make primer handling optional

### DIFF
--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -64,11 +64,14 @@ workflow ILLUMINA {
 
         }
 
-        METAGENOMICS(
-            ch_metagenome_ref,
-            PRIMER_HANDLING.out,
-            Channel.empty()
+        if ( params.primer_bed ) {
+            
+            METAGENOMICS(
+                ch_metagenome_ref,
+                PRIMER_HANDLING.out,
+                Channel.empty()
         )
+        }
 
         CONSENSUS (
             ALIGNMENT.out


### PR DESCRIPTION
I recently ran Oneroof without providing a bed file, which should just turn off primer handling. However, it erred even before starting since PRIMER_HANDLING is necessary as input to METAGENOMICS. I added an if statement so that METAGENOMICS will only run if a bed file is actually given, allowing the user to opt out of primer handling without an error.